### PR TITLE
[Feat] 닉네임 설정 기능 및 마이페이지 생성

### DIFF
--- a/src/main/java/com/ll/olol/boundedContext/member/controller/MemberController.java
+++ b/src/main/java/com/ll/olol/boundedContext/member/controller/MemberController.java
@@ -1,0 +1,53 @@
+package com.ll.olol.boundedContext.member.controller;
+
+import com.ll.olol.base.rq.Rq;
+import com.ll.olol.base.rsData.RsData;
+import com.ll.olol.boundedContext.member.service.MemberService;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequestMapping("/member")
+@RequiredArgsConstructor
+public class MemberController {
+    private final Rq rq;
+    private final MemberService memberService;
+
+
+    @PreAuthorize("isAuthenticated()")
+    @GetMapping("/mypage")
+    public String showMyPage() {
+        return "usr/layout/myPage";
+    }
+
+    @AllArgsConstructor
+    @Getter
+    public static class EditForm {
+        @NotBlank
+        @Size(min = 2, max = 10)
+        private final String nickname;
+    }
+
+    @PreAuthorize("isAuthenticated()")
+    @PostMapping("/mypage")
+    public String editInfo(@Valid EditForm editForm) {
+        RsData result = memberService.modifyMemberInfo(rq.getMember(), editForm.getNickname());
+
+        if (result.isFail()) {
+            rq.historyBack("다시시도해주세요");
+        }
+
+        return "redirect:/";
+    }
+
+
+}

--- a/src/main/java/com/ll/olol/boundedContext/member/service/MemberService.java
+++ b/src/main/java/com/ll/olol/boundedContext/member/service/MemberService.java
@@ -56,4 +56,12 @@ public class MemberService {
 
         return join(providerTypeCode, username, "");
     }
+
+    @Transactional
+    public RsData modifyMemberInfo(Member member, String nickname) {
+        Member resultMember = memberRepository.findById(member.getId()).get();
+        resultMember.setNickname(nickname);
+        memberRepository.save(resultMember);
+        return RsData.of("S-1", "닉네임 수정 성공");
+    }
 }

--- a/src/main/resources/templates/usr/layout/layout.html
+++ b/src/main/resources/templates/usr/layout/layout.html
@@ -29,7 +29,7 @@
                             My Menu
                         </button>
                         <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
-                            <a class="dropdown-item" href="/">설정</a>
+                            <a class="dropdown-item" th:href="@{/member/mypage}">마이페이지</a>
                             <a class="dropdown-item" th:href="@{/user/logout}">로그아웃</a>
                         </div>
                     </div>

--- a/src/main/resources/templates/usr/layout/myPage.html
+++ b/src/main/resources/templates/usr/layout/myPage.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<body>
+<div class="container mt-5">
+    <script>
+        function MyPageForm__submit(form) {
+
+            form.nickname.value = form.nickname.value.trim(); // 입력란의 입력값에 있을지 모르는 좌우공백제거
+
+            if (form.nickname.value.length == 0) {
+                form.nickname.focus();
+                toastWarning('닉네임을 입력해주세요.');
+                return;
+            }
+
+            if (form.nickname.value.length < 2) {
+                toastWarning('닉네임을 2자 이상 입력해주세요.');
+                form.nickname.focus();
+                return;
+            }
+
+            if (form.nickname.value.length > 10) {
+                toastWarning('닉네임을 10자 이하로 입력해주세요.');
+                form.nickname.focus();
+                return;
+            }
+
+            form.submit(); // 폼 발송
+        }
+    </script>
+    <h2>회원정보 수정</h2>
+    <form onsubmit="MyPageForm__submit(this);" th:action method="POST">
+        <div class="mb-3">
+            <label for="nickname" class="form-label">닉네임</label>
+            <input type="text" class="form-control" id="nickname" name="nickname" required>
+        </div>
+        <div class="mb-3">
+            <button type="submit" class="btn btn-primary">수정완료</button>
+            <button type="button" class="btn btn-secondary" onclick="window.history.back()">취소</button>
+        </div>
+
+    </form>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+</body>


### PR DESCRIPTION
### 📝 Description

- 닉네임 설정을 위한 마이페이지 생성
- 현재 마이페이지는 기초 레이아웃(미완)이며, 추후에 변경 예정

### 💻 How To Test

1. 카카오, 네이버, 구글을 통해 로그인
2. 로그인 이후 드롭다운 메뉴 中 '마이페이지' (/member/mypage)를 통해 닉네임 입력 후 버튼 클릭시 닉네임 변경

### 🖼 결과

![image](https://github.com/yoonjoonseok/OLOL_service/assets/66302122/bd2f1877-354d-43f2-b242-872cfa4ed12b)

![image](https://github.com/yoonjoonseok/OLOL_service/assets/66302122/b6af97e9-9a89-4643-88c6-92cea6e8698d)

![image](https://github.com/yoonjoonseok/OLOL_service/assets/66302122/fb04de83-54b2-4299-ae47-c32d124269d2)

close #20 