### PR TITLE
로그인 객체에 추가정보 없을 시 동작 block 

### DIFF
--- a/src/main/java/com/ll/olol/boundedContext/member/service/MemberService.java
+++ b/src/main/java/com/ll/olol/boundedContext/member/service/MemberService.java
@@ -67,4 +67,8 @@ public class MemberService {
         memberRepository.save(resultMember);
         return RsData.of("S-1", "닉네임 수정 성공");
     }
+
+    public boolean hasAdditionalInfo(Member loginedMember) {
+        return loginedMember.getEmail() != null || loginedMember.getNickname() != null;
+    }
 }

--- a/src/main/java/com/ll/olol/boundedContext/notification/controller/NotificationController.java
+++ b/src/main/java/com/ll/olol/boundedContext/notification/controller/NotificationController.java
@@ -1,6 +1,8 @@
 package com.ll.olol.boundedContext.notification.controller;
 
 import com.ll.olol.base.rq.Rq;
+import com.ll.olol.boundedContext.member.entity.Member;
+import com.ll.olol.boundedContext.member.service.MemberService;
 import com.ll.olol.boundedContext.notification.entity.Notification;
 import com.ll.olol.boundedContext.notification.service.NotificationService;
 import lombok.RequiredArgsConstructor;
@@ -20,9 +22,15 @@ import java.util.List;
 public class NotificationController {
     private final Rq rq;
     private final NotificationService notificationService;
+    private final MemberService memberService;
 
     @GetMapping("/list")
     public String showList(Model model) {
+
+        Member loginedMember = rq.getMember();
+        if (!memberService.hasAdditionalInfo(loginedMember)) {
+            return rq.historyBack("마이페이지에서 추가정보를 입력해주세요.");
+        }
 
         List<Notification> notifications = notificationService.findByToInstaMember(rq.getMember());
 

--- a/src/main/java/com/ll/olol/boundedContext/recruitment/controller/RecruitmentController.java
+++ b/src/main/java/com/ll/olol/boundedContext/recruitment/controller/RecruitmentController.java
@@ -7,6 +7,7 @@ import com.ll.olol.boundedContext.comment.entity.CommentDto;
 import com.ll.olol.boundedContext.comment.service.CommentService;
 import com.ll.olol.boundedContext.member.entity.Member;
 import com.ll.olol.boundedContext.member.repository.MemberRepository;
+import com.ll.olol.boundedContext.member.service.MemberService;
 import com.ll.olol.boundedContext.recruitment.CreateForm;
 import com.ll.olol.boundedContext.recruitment.entity.RecruitmentArticle;
 import com.ll.olol.boundedContext.recruitment.entity.RecruitmentPeople;
@@ -37,6 +38,7 @@ public class RecruitmentController {
     private final Rq rq;
     private final RecruitmentService recruitmentService;
     private final MemberRepository memberRepository;
+    private final MemberService memberService;
     private final CommentService commentService;
     private final RecruitmentPeopleService recruitmentPeopleService;
     private int limitPeople = 0;
@@ -45,6 +47,12 @@ public class RecruitmentController {
     @GetMapping("/create")
     // @Valid를 붙여야 QuestionForm.java내의 NotBlank나 Size가 동작한다.
     public String questionCreate2(CreateForm createForm) {
+
+        Member loginedMember = rq.getMember();
+        if (!memberService.hasAdditionalInfo(loginedMember)) {
+            return rq.historyBack("마이페이지에서 추가정보를 입력해주세요.");
+        }
+
         return "recruitmentArticle/createRecruitment_form";
     }
 
@@ -123,6 +131,12 @@ public class RecruitmentController {
     @PreAuthorize("isAuthenticated()")
     @GetMapping("/fromList")
     public String showFromAttendList(Model model) {
+
+        Member loginedMember = rq.getMember();
+        if (!memberService.hasAdditionalInfo(loginedMember)) {
+            return rq.historyBack("마이페이지에서 추가정보를 입력해주세요.");
+        }
+
         Long memberId = rq.getMember().getId();
         List<RecruitmentArticle> all = recruitmentService.findAll();
         List<RecruitmentPeople> list = new ArrayList<>();


### PR DESCRIPTION
### 📝 Description

- 로그인 객체에 닉네임, 이메일등 추가정보 없을 시 게시글 등록, 참가자 목록 불가하도록 막았습니다. 

close #111 